### PR TITLE
Migrate AI integration to OpenRouter provider

### DIFF
--- a/OPENROUTER_INTEGRATION.md
+++ b/OPENROUTER_INTEGRATION.md
@@ -1,0 +1,72 @@
+# OpenRouter Integration Summary
+
+## Changes Made
+
+This document summarizes the changes made to integrate OpenRouter for Manim code generation instead of using Google AI SDK directly.
+
+### Files Modified
+
+1. **`src/utils/structuredManimGenerator.ts`**
+   - Replaced `@ai-sdk/google` import with `@openrouter/ai-sdk-provider`
+   - Updated model from `google('gemini-1.5-flash')` to `openrouter("google/gemini-flash-1.5")`
+   - Added OpenRouter provider initialization
+
+2. **`src/utils/lessonBreakdown.ts`**
+   - Replaced `@ai-sdk/google` import with `@openrouter/ai-sdk-provider`
+   - Updated model from `google("gemini-1.5-flash")` to `openrouter("google/gemini-flash-1.5")`
+   - Added OpenRouter provider initialization
+
+3. **`src/utils/voiceNarration.ts`**
+   - Replaced `@ai-sdk/google` import with `@openrouter/ai-sdk-provider`
+   - Updated model from `google('gemini-1.5-flash')` to `openrouter("google/gemini-flash-1.5")`
+   - Added OpenRouter provider initialization
+
+4. **`.env.example`**
+   - Updated to include `OPENROUTER_API_KEY` configuration
+   - Removed deprecated `GOOGLE_GENERATIVE_AI_API_KEY`
+   - Added better documentation for all required environment variables
+
+5. **`README.md`**
+   - Updated tech stack to reflect OpenRouter usage
+   - Updated prerequisites and environment setup instructions
+   - Updated API key requirements
+
+### Benefits of OpenRouter Integration
+
+1. **Model Flexibility**: OpenRouter provides access to multiple AI models through a single API
+2. **Cost Optimization**: Can switch between different models based on cost and performance needs
+3. **Reliability**: Improved reliability through OpenRouter's infrastructure
+4. **Consistency**: All AI-powered features now use the same provider
+
+### Environment Variables Required
+
+```env
+# Primary AI provider for code generation
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# Text-to-speech for voice narration
+MURF_AI_API_KEY=your_murf_ai_api_key_here
+
+# Code execution sandbox
+E2B_API_KEY=your_e2b_api_key_here
+
+# File storage for caching
+BLOB_READ_WRITE_TOKEN=your_vercel_blob_token_here
+```
+
+### Model Configuration
+
+The integration uses `google/gemini-flash-1.5` through OpenRouter, which provides:
+- Fast response times suitable for real-time applications
+- Good performance for code generation tasks
+- Cost-effective pricing structure
+
+### Testing
+
+To test the integration:
+1. Set up your OpenRouter API key in environment variables
+2. Run the development server: `bun dev`
+3. Try generating Manim code through the application
+4. Verify that lesson breakdown and voice narration features work correctly
+
+The changes maintain backward compatibility with existing functionality while providing better flexibility for future AI model selections.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Next.js application that generates educational mathematical animations using M
 
 - **Frontend**: Next.js 15, React 19, TypeScript
 - **Styling**: Tailwind CSS 4, Paper Design Shaders
-- **AI**: Google AI SDK, OpenAI SDK
+- **AI**: OpenRouter (Gemini Flash 1.5), Murf AI for TTS
 - **Sandbox**: E2B Code Interpreter
 - **Animation**: Manim (Mathematical Animation Engine)
 - **Package Manager**: Bun
@@ -25,7 +25,7 @@ A Next.js application that generates educational mathematical animations using M
 
 - Node.js 18+ or Bun
 - E2B account and API key
-- OpenAI or Google AI API key
+- OpenRouter API key (for AI-powered code generation)
 
 ### Installation
 
@@ -46,8 +46,9 @@ A Next.js application that generates educational mathematical animations using M
    Create a `.env.local` file with your API keys:
    ```env
    E2B_API_KEY=your_e2b_api_key
-   OPENAI_API_KEY=your_openai_api_key
-   GOOGLE_AI_API_KEY=your_google_ai_api_key
+   OPENROUTER_API_KEY=your_openrouter_api_key
+   MURF_AI_API_KEY=your_murf_ai_api_key
+   BLOB_READ_WRITE_TOKEN=your_vercel_blob_token
    ```
 
 4. **Run the development server**

--- a/StringTheoryScene.py
+++ b/StringTheoryScene.py
@@ -22,8 +22,8 @@ class StringTheoryScene(Scene):
         self.play(Create(string_line))
         self.wait(1)
 
-        # Step 4: Label the string with a MathTex object.
-        string_label = MathTex(r"\text{Vibrating String}")
+        # Step 4: Label the string with a Text object.
+        string_label = Text("Vibrating String")
         string_label.next_to(string_line, UP, buff=0.2)
         self.play(Write(string_label))
         self.wait(1)
@@ -37,7 +37,7 @@ class StringTheoryScene(Scene):
         self.wait(1)
 
         # Step 6: Label the extra dimensions.
-        extra_label = MathTex(r"\text{Extra Dimensions}")
+        extra_label = Text("Extra Dimensions")
         extra_label.next_to(extra_dimensions, DOWN, buff=0.1)
         self.play(Write(extra_label))
         self.wait(1)

--- a/src/utils/lessonBreakdown.ts
+++ b/src/utils/lessonBreakdown.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { blobStorage } from "./blobStorage";
 import { generateObject } from "ai";
-import { google } from "@ai-sdk/google";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+
+// Initialize the OpenRouter provider
+const openrouter = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY || '',
+});
 
 // Schema for lesson breakdown
 const lessonBreakdownSchema = z.object({
@@ -51,7 +56,7 @@ export async function generateLessonBreakdown(topic: string): Promise<{
       `🔄 Storage MISS - Generating new lesson breakdown for: ${topic}`
     );
     const { object } = await generateObject({
-      model: google("gemini-1.5-flash"),
+      model: openrouter("google/gemini-flash-1.5"),
       schema: lessonBreakdownSchema,
       prompt: `Break down the topic "${topic}" into 3-4 sequential mini-lessons for educational animation.
 
@@ -74,6 +79,7 @@ MANIM CODE RULES:
 - Keep animations lightweight and fast
 - Focus on visual clarity over complexity
 - Use only basic Manim objects: Text, MathTex, Circle, Square, Line, Arrow
+- Use Text() for plain text labels, never use MathTex with \\text{}
 - Always use MathTex for mathematical expressions, never use Tex
 - Position objects with next_to() method
 - Use simple animations: Write, FadeIn, FadeOut, Transform

--- a/src/utils/voiceNarration.ts
+++ b/src/utils/voiceNarration.ts
@@ -2,8 +2,13 @@ import axios from "axios";
 import { blobStorage } from "./blobStorage";
 
 import { generateObject } from "ai";
-import { google } from "@ai-sdk/google";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { z } from "zod";
+
+// Initialize the OpenRouter provider
+const openrouter = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY || '',
+});
 
 // Schema for narration script generation
 const narrationScriptSchema = z.object({
@@ -54,7 +59,7 @@ export async function generateNarrationScript(topic: string): Promise<{
   // Generate AI-powered voice narration script
     
     const { object } = await generateObject({
-      model: google('gemini-1.5-flash'),
+      model: openrouter("google/gemini-flash-1.5"),
       schema: narrationScriptSchema,
       prompt: `Generate a BASIC OVERVIEW voice narration for a Manim animation about: "${topic}"
 


### PR DESCRIPTION
Replaced all usage of @ai-sdk/google with @openrouter/ai-sdk-provider in lesson breakdown, Manim code generation, and voice narration utilities. Updated model selection to use OpenRouter's Gemini Flash 1.5 and DeepSeek models. Adjusted prompt instructions and code validation to enforce using Text() for plain text labels instead of MathTex with \text{}. Updated README and added OPENROUTER_INTEGRATION.md to document the migration, environment variables, and benefits of the new provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated AI provider to OpenRouter for code generation and narration.
  - Plain text labels in generated Manim scenes now use Text instead of MathTex.

- Bug Fixes
  - Improved handling of plain text in Manim output by converting MathTex with \text{} to Text, reducing rendering issues.

- Documentation
  - Added OpenRouter integration guide with setup and testing steps.
  - Updated README with new AI stack, prerequisites, and environment variables.

- Chores
  - Environment changes: require OPENROUTER_API_KEY; removed legacy Google/OpenAI keys.
  - Updated examples and prompts to reflect Text-based labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->